### PR TITLE
Symfony 3.4 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- services.yml updated to Symfony 3.4 best practices (@TomasLudvik)
+
 ## [0.2.2] - 2017-10-04
 ### Added
 - support for [shopsys/product-feed-interface](shopsys/product-feed-interface) 0.5.0 (@PetrHeinz)

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,5 +1,9 @@
 services:
-  shopsys.product_feed.heureka_delivery_bundle.feed_config:
-    class: Shopsys\ProductFeed\HeurekaDeliveryBundle\HeurekaDeliveryFeedConfig
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  Shopsys\ProductFeed\HeurekaDeliveryBundle\HeurekaDeliveryFeedConfig:
     tags:
       - { name: shopsys.product_feed, type: delivery }


### PR DESCRIPTION
**Description, reason for the PR:** upgrade of the main repository to Symfony 3.4

**New feature:** No

**BC breaks:** No

**Fixes issues:** None

**Standards and tests pass:** Yes

**License:** MIT
